### PR TITLE
[Neo4J Helm Chart] Adds support for allowing overrides to liveness, readiness, and startup probes

### DIFF
--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -478,8 +478,8 @@ startupProbe:
   {{- if .successThreshold }}
   successThreshold: {{ .successThreshold }}
   {{- end }}
-  # If no probe action is set, default to using tcpSocket probe to check port 7687 to check if bolt connections can be made
   {{- if not (or .exec .grpc .httpGet .tcpSocket) }}
+  # If no probe action is set, default to using tcpSocket probe to check port 7687 to check if bolt connections can be made
   tcpSocket:
     port: 7687
   {{- end }}

--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -387,12 +387,12 @@ readinessProbe:
   {{- toYaml .exec | nindent 4 }}  
   {{- else if .grpc }}
   grpc: 
-  {{- toYaml .grpc | indent 4 }}
+  {{- toYaml .grpc | nindent 4 }}
   {{- else if .httpGet }}
-  httpGet: {{ toYaml .httpGet | indent 4 }}
+  httpGet: {{ toYaml .httpGet | nindent 4 }}
   {{- else if .tcpSocket }}
   tcpSocket:
-  {{- toYaml .tcpSocket | indent 4 }}
+  {{- toYaml .tcpSocket | nindent 4 }}
   {{- end }}
   {{- if .initialDelaySeconds }}
   initialDelaySeconds: {{ .initialDelaySeconds }}
@@ -423,12 +423,12 @@ livenessProbe:
   {{- toYaml .exec | nindent 4 }}  
   {{- else if .grpc }}
   grpc: 
-  {{- toYaml .grpc | indent 4 }}
+  {{- toYaml .grpc | nindent 4 }}
   {{- else if .httpGet }}
-  httpGet: {{ toYaml .httpGet | indent 4 }}
+  httpGet: {{ toYaml .httpGet | nindent 4 }}
   {{- else if .tcpSocket }}
   tcpSocket:
-  {{- toYaml .tcpSocket | indent 4 }}
+  {{- toYaml .tcpSocket | nindent 4 }}
   {{- end }}
   {{- if .initialDelaySeconds }}
   initialDelaySeconds: {{ .initialDelaySeconds }}
@@ -459,12 +459,12 @@ startupProbe:
   {{- toYaml .exec | nindent 4 }}  
   {{- else if .grpc }}
   grpc: 
-  {{- toYaml .grpc | indent 4 }}
+  {{- toYaml .grpc | nindent 4 }}
   {{- else if .httpGet }}
-  httpGet: {{ toYaml .httpGet | indent 4 }}
+  httpGet: {{ toYaml .httpGet | nindent 4 }}
   {{- else if .tcpSocket }}
   tcpSocket:
-  {{- toYaml .tcpSocket | indent 4 }}
+  {{- toYaml .tcpSocket | nindent 4 }}
   {{- end }}
   {{- if .initialDelaySeconds }}
   initialDelaySeconds: {{ .initialDelaySeconds }}

--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -391,7 +391,7 @@ readinessProbe:
   {{- else if .httpGet }}
   httpGet: {{ toYaml .httpGet | indent 2 }}
   {{- else if .tcpSocket }}
-  tcpSocket: 
+  tcpSocket:
   {{ toYaml .tcpSocket | indent 2 }}
   {{- end }}
   {{- if .initialDelaySeconds }}
@@ -427,7 +427,7 @@ livenessProbe:
   {{- else if .httpGet }}
   httpGet: {{ toYaml .httpGet | indent 2 }}
   {{- else if .tcpSocket }}
-  tcpSocket: 
+  tcpSocket:
   {{ toYaml .tcpSocket | indent 2 }}
   {{- end }}
   {{- if .initialDelaySeconds }}
@@ -463,7 +463,7 @@ startupProbe:
   {{- else if .httpGet }}
   httpGet: {{ toYaml .httpGet | indent 2 }}
   {{- else if .tcpSocket }}
-  tcpSocket: 
+  tcpSocket:
   {{ toYaml .tcpSocket | indent 2 }}
   {{- end }}
   {{- if .initialDelaySeconds }}

--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -384,15 +384,15 @@ readinessProbe:
   # Allow overriding the probe action
   {{- if .exec }}
   exec: 
-  {{ toYaml .exec | indent 2 }}  
+  {{- toYaml .exec | nindent 4 }}  
   {{- else if .grpc }}
   grpc: 
-  {{ toYaml .grpc | indent 2 }}
+  {{- toYaml .grpc | indent 4 }}
   {{- else if .httpGet }}
-  httpGet: {{ toYaml .httpGet | indent 2 }}
+  httpGet: {{ toYaml .httpGet | indent 4 }}
   {{- else if .tcpSocket }}
   tcpSocket:
-  {{ toYaml .tcpSocket | indent 2 }}
+  {{- toYaml .tcpSocket | indent 4 }}
   {{- end }}
   {{- if .initialDelaySeconds }}
   initialDelaySeconds: {{ .initialDelaySeconds }}
@@ -420,15 +420,15 @@ livenessProbe:
   # Allow overriding the probe action
   {{- if .exec }}
   exec: 
-  {{ toYaml .exec | indent 2 }}  
+  {{- toYaml .exec | nindent 4 }}  
   {{- else if .grpc }}
   grpc: 
-  {{ toYaml .grpc | indent 2 }}
+  {{- toYaml .grpc | indent 4 }}
   {{- else if .httpGet }}
-  httpGet: {{ toYaml .httpGet | indent 2 }}
+  httpGet: {{ toYaml .httpGet | indent 4 }}
   {{- else if .tcpSocket }}
   tcpSocket:
-  {{ toYaml .tcpSocket | indent 2 }}
+  {{- toYaml .tcpSocket | indent 4 }}
   {{- end }}
   {{- if .initialDelaySeconds }}
   initialDelaySeconds: {{ .initialDelaySeconds }}
@@ -456,15 +456,15 @@ startupProbe:
   # Allow overriding the probe action
   {{- if .exec }}
   exec: 
-  {{ toYaml .exec | indent 2 }}  
+  {{- toYaml .exec | nindent 4 }}  
   {{- else if .grpc }}
   grpc: 
-  {{ toYaml .grpc | indent 2 }}
+  {{- toYaml .grpc | indent 4 }}
   {{- else if .httpGet }}
-  httpGet: {{ toYaml .httpGet | indent 2 }}
+  httpGet: {{ toYaml .httpGet | indent 4 }}
   {{- else if .tcpSocket }}
   tcpSocket:
-  {{ toYaml .tcpSocket | indent 2 }}
+  {{- toYaml .tcpSocket | indent 4 }}
   {{- end }}
   {{- if .initialDelaySeconds }}
   initialDelaySeconds: {{ .initialDelaySeconds }}

--- a/neo4j/templates/_helpers.tpl
+++ b/neo4j/templates/_helpers.tpl
@@ -376,3 +376,113 @@ topologySpreadConstraints:
 {{ toYaml $.Values.podSpec.topologySpreadConstraints }}
     {{- end }}
 {{- end -}}
+
+{{- define "neo4j.readinessProbe" -}}
+# Allow user to override the readinessProbe settings for advanced use cases
+# See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#probe-v1-core
+readinessProbe:
+  # Allow overriding the probe action
+  {{- if .exec }}
+  exec: 
+  {{ toYaml .exec | indent 2 }}  
+  {{- else if .grpc }}
+  grpc: 
+  {{ toYaml .grpc | indent 2 }}
+  {{- else if .httpGet }}
+  httpGet: {{ toYaml .httpGet | indent 2 }}
+  {{- else if .tcpSocket }}
+  tcpSocket: 
+  {{ toYaml .tcpSocket | indent 2 }}
+  {{- end }}
+  {{- if .initialDelaySeconds }}
+  initialDelaySeconds: {{ .initialDelaySeconds }}
+  {{- end }}
+  {{- if .terminationGracePeriodSeconds }}
+  terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
+  {{- end }}
+  {{- if .successThreshold }}
+  successThreshold: {{ .successThreshold }}
+  {{- end }}
+  # If no probe action is set, default to using tcpSocket probe to check port 7687 to check if bolt connections can be made
+  {{- if not (or .exec .grpc .httpGet .tcpSocket) }}
+  tcpSocket:
+    port: 7687
+  {{- end }}
+  failureThreshold: {{ .failureThreshold | default 20 }}
+  timeoutSeconds: {{ .timeoutSeconds | default 10 }}
+  periodSeconds: {{ .periodSeconds | default 5 }}
+{{- end -}}
+
+{{- define "neo4j.livenessProbe" -}}
+# Allow user to override the livenessProbe settings for advanced use cases
+# See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#probe-v1-core
+livenessProbe:
+  # Allow overriding the probe action
+  {{- if .exec }}
+  exec: 
+  {{ toYaml .exec | indent 2 }}  
+  {{- else if .grpc }}
+  grpc: 
+  {{ toYaml .grpc | indent 2 }}
+  {{- else if .httpGet }}
+  httpGet: {{ toYaml .httpGet | indent 2 }}
+  {{- else if .tcpSocket }}
+  tcpSocket: 
+  {{ toYaml .tcpSocket | indent 2 }}
+  {{- end }}
+  {{- if .initialDelaySeconds }}
+  initialDelaySeconds: {{ .initialDelaySeconds }}
+  {{- end }}
+  {{- if .terminationGracePeriodSeconds }}
+  terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
+  {{- end }}
+  {{- if .successThreshold }}
+  successThreshold: {{ .successThreshold }}
+  {{- end }}
+  # If no probe action is set, default to using tcpSocket probe to check port 7687 to check if bolt connections can be made
+  {{- if not (or .exec .grpc .httpGet .tcpSocket) }}
+  tcpSocket:
+    port: 7687
+  {{- end }}
+  failureThreshold: {{ .failureThreshold | default 40 }}
+  timeoutSeconds: {{ .timeoutSeconds | default 10}}
+  periodSeconds: {{ .periodSeconds | default 5 }}
+{{- end -}}
+
+{{- define "neo4j.startupProbe" -}}
+# Allow user to override the startupProbe settings for advanced use cases
+# See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#probe-v1-core
+startupProbe:
+  # Allow overriding the probe action
+  {{- if .exec }}
+  exec: 
+  {{ toYaml .exec | indent 2 }}  
+  {{- else if .grpc }}
+  grpc: 
+  {{ toYaml .grpc | indent 2 }}
+  {{- else if .httpGet }}
+  httpGet: {{ toYaml .httpGet | indent 2 }}
+  {{- else if .tcpSocket }}
+  tcpSocket: 
+  {{ toYaml .tcpSocket | indent 2 }}
+  {{- end }}
+  {{- if .initialDelaySeconds }}
+  initialDelaySeconds: {{ .initialDelaySeconds }}
+  {{- end }}
+  {{- if .timeoutSeconds }}
+  timeoutSeconds: {{ .timeoutSeconds }}
+  {{- end }}
+  {{- if .terminationGracePeriodSeconds }}
+  terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
+  {{- end }}
+  {{- if .successThreshold }}
+  successThreshold: {{ .successThreshold }}
+  {{- end }}
+  # If no probe action is set, default to using tcpSocket probe to check port 7687 to check if bolt connections can be made
+  {{- if not (or .exec .grpc .httpGet .tcpSocket) }}
+  tcpSocket:
+    port: 7687
+  {{- end }}
+  failureThreshold: {{ .failureThreshold | default 1000 }}
+  periodSeconds: {{ .periodSeconds | default 5 }}
+{{- end -}}

--- a/neo4j/templates/neo4j-statefulset.yaml
+++ b/neo4j/templates/neo4j-statefulset.yaml
@@ -155,26 +155,13 @@ spec:
             {{- if $offlineMaintenanceEnabled  }}
             {{- include "neo4j.maintenanceVolumeMounts" .Values.volumes | indent 12 }}
             {{- end }}
-          readinessProbe:
-            tcpSocket:
-              port: 7687
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- include "neo4j.readinessProbe" .Values.readinessProbe | nindent 10 }}  
+          
           {{- if $offlineMaintenanceEnabled }}
           # liveness and startup probes are disabled in offlineMaintenanceMode
           {{- else }}
-          livenessProbe:
-            tcpSocket:
-              port: 7687
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          startupProbe:
-            tcpSocket:
-              port: 7687
-            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
-            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          {{- include "neo4j.livenessProbe" .Values.livenessProbe | nindent 10 }}
+          {{- include "neo4j.startupProbe" .Values.startupProbe | nindent 10 }}
           {{- end }}
         {{- with .Values.podSpec.containers }}
         # Extra "sidecar" containers

--- a/neo4j/values.yaml
+++ b/neo4j/values.yaml
@@ -367,6 +367,8 @@ containerSecurityContext:
 # Because Neo4j uses Java these values are large to distinguish between long Garbage Collection pauses (which don't require a restart) and an actual failure.
 # These values should mark Neo4j as not ready after at most 5 minutes of problems (20 attempts * max 15 seconds between probes)
 readinessProbe:
+  tcpSocket:
+    port: 7687
   failureThreshold: 20
   timeoutSeconds: 10
   periodSeconds: 5
@@ -375,6 +377,8 @@ readinessProbe:
 # Because Neo4j uses Java these values are large to distinguish between long Garbage Collection pauses (which don't require a restart) and an actual failure.
 # These values should trigger a restart after at most 10 minutes of problems (40 attempts * max 15 seconds between probes)
 livenessProbe:
+  tcpSocket:
+    port: 7687
   failureThreshold: 40
   timeoutSeconds: 10
   periodSeconds: 5
@@ -384,6 +388,8 @@ livenessProbe:
 # When restoring Neo4j from a backup it's important that startup probe gives time for Neo4j to recover and/or upgrade store files
 # When using Neo4j clusters it's important that startup probe give the Neo4j cluster time to form
 startupProbe:
+  tcpSocket:
+    port: 7687
   failureThreshold: 1000
   periodSeconds: 5
 


### PR DESCRIPTION
Adds support for allowing overrides to liveness, readiness, and startup probes

Preserves backward compatibility with existing consumers of Neo4J helm chart

Tested by performing dry run of helm chart on main branch vs this feature branch and performing diff of manifests to ensure defaulted values causes manifests to render same values.

dev branch:

helm template ./neo4j --debug --dry-run --set neo4j.name=test-neo4j-cluster --set volumes.data.mode=defaultStorageClass > neo4j-cluster-manifests-dev-branch.yaml

Feature branch:
helm template ./neo4j --debug --dry-run --set neo4j.name=test-neo4j-cluster --set volumes.data.mode=defaultStorageClass > neo4j-cluster-manifests-with-updates.yaml

Then diffed the files.

Related Issue: https://github.com/neo4j/helm-charts/issues/337