### PR TITLE
fix(svc): expose internals discovery ports when internals explicitly enabled

### DIFF
--- a/neo4j/templates/neo4j-svc.yaml
+++ b/neo4j/templates/neo4j-svc.yaml
@@ -168,8 +168,11 @@ spec:
       targetPort: 7473
       name: tcp-https
     {{- end }}
-    {{- if or $clusterEnabled $.Values.analytics.enabled }}
+    {{- if or $clusterEnabled $.Values.analytics.enabled $.Values.services.internals.enabled }}
     #enable the ports for non Read Replicas
+    # internals.enabled also exposes the discovery ports below for standalone
+    # (non-clustered) instances that still use the K8S discovery resolver; without
+    # them the resolver returns an empty endpoint list and Bolt never opens.
     - protocol: TCP
       port: 7688
       targetPort: 7688


### PR DESCRIPTION
## Problem

A standalone (non-clustered, `minimumClusterSize=1`) Neo4j instance that uses the K8S discovery resolver fails to become Ready. Startup log:

```
Resolved endpoints with K8S{...,portName:'transaction',labelSelector:'...,helm.neo4j.com/clustering=false',...} to '[]'
```

### Root cause

The `internals` Service gates its cluster/discovery ports behind `{{- if or $clusterEnabled $.Values.analytics.enabled }}`: `tcp-boltrouting` (7688), `tcp-discovery` (5000), `tcp-raft` (7000), `tcp-tx` (6000).

When `services.internals.enabled: true` is set for a **non-clustered** instance (Service renders with `clustering=false`, `publishNotReadyAddresses: true`), it exposes **none** of the discovery ports. A consumer with `dbms.cluster.discovery.resolver_type: K8S` + `dbms.kubernetes.service_port_name: tcp-discovery` queries the internals endpoints for a port that does not exist, gets `[]`, never opens Bolt, and the pod stays `0/1`.

## Fix

```diff
- {{- if or $clusterEnabled $.Values.analytics.enabled }}
+ {{- if or $clusterEnabled $.Values.analytics.enabled $.Values.services.internals.enabled }}
```

## Blast radius

`services.internals.enabled` defaults to `false`, so this is opt-in and changes nothing for deployments that don't set it.

## Verification (`helm template`)

| Scenario | `clustering` label | discovery ports |
|---|---|---|
| standalone + `internals.enabled=true` | `false` | **present** (was absent) |
| standalone, `internals` default (false) | n/a | absent (unchanged) |
| clustered (`minimumClusterSize=3`) | `true` | present (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)